### PR TITLE
fix: correct command name in readme

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,6 +20,6 @@ A clear and concise description of what the bug is.
 
 A clear and concise description of what you expected to happen.
 
-### Which version of the SDK are you using?
+### Which version of the CLI are you using?
 
 e.g. 1.0.0

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           message-id: "bundle-size-comparison"
           message: |
-            Thank you for contributing to the HellHub SDK fellow Helldiver! We try to keep our bundle size as small as possible, here you can see the impact of your pull request to the main bundle.
+            Thank you for contributing to the HellHub CLI fellow Helldiver! We try to keep our bundle size as small as possible, here you can see the impact of your pull request to the main bundle.
 
             | 📦 Main                    | 🚀 PR                        | 📁 Generated Files           |
             |----------------------------|------------------------------|------------------------------|

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/hellhub-collective/sdk">
+  <a href="https://github.com/hellhub-collective/cli">
     <img src="https://raw.githubusercontent.com/hellhub-collective/cli/main/assets/logo.png" width="150px" alt="HellHub CLI Logo" />
   </a>
 </p>
@@ -62,4 +62,4 @@ export HELLHUB_API_URL="https://my-hellhub-api.com/api"
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](https://github.com/hellhub-collective/sdk/blob/main/LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE](https://github.com/hellhub-collective/cli/blob/main/LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ bun -g add @hellhub-collective/cli
 To use the HellHub CLI, you can simply type the `hellhub` keyword into your terminal. Let's look at a example command:
 
 ```bash
-hellhub statistics --limit 10 --filters="planet:name:@not:a"
+hellhub statistics --limit 10 --filters="planet:name:@contains:a"
 ```
 
 This command will output the statistics for the first 10 planets that do contain the letter "a" in their name:


### PR DESCRIPTION
## Description

This PR fixes the command name inside the example section of the readme.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
