### PR TITLE
fix: add node env shebang for cross package-manager compatibility

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { Command } from "commander";
 import { bin, description, version } from "package.json";
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "private": false,
   "description": "The official CLI for HellHub API. Stay updated about the current war right without leaving your terminal.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "build/index.mjs",
   "types": "build/index.d.ts",
   "keywords": [


### PR DESCRIPTION
## Description

Add a `#!/usr/bin/env node` shebang at the top of the file to indicate where to run the script. This does not discriminate the runtime while still being supported by bun.

Fixes #6 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
