### PR TITLE
fix: replace `Bun.argv` with `process.argv` for node compatibility

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -26,4 +26,4 @@ program
   com => com(program),
 );
 
-program.parse(Bun.argv);
+program.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "private": false,
   "description": "The official CLI for HellHub API. Stay updated about the current war right without leaving your terminal.",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "build/index.mjs",
   "types": "build/index.d.ts",
   "keywords": [

--- a/utils/ascii.ts
+++ b/utils/ascii.ts
@@ -5,7 +5,7 @@ export default async function ascii(
   name: string,
   replace: Record<string, string> = {},
 ) {
-  if (Bun.argv.includes("--no-ascii") || Bun.argv.includes("-a")) {
+  if (process.argv.includes("--no-ascii") || process.argv.includes("-a")) {
     return;
   }
 


### PR DESCRIPTION
## Description

Should finally fix the ongoing issue that the CLI is not runnable on a system where bun is not installed.

Fixes #6

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1.  Created the build output
2. Uninstalled bun
3. Ran `node build/index.mjs planets`
4. Successfully executed command

### Test Configuration

- CLI version: 1.2.4

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
