### PR TITLE
fix: correctly replace url value

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,7 +16,7 @@ const program = new Command();
 const programVersion = version;
 const programDescription = description;
 const programName = Object.keys(bin)[0];
-const helpText = `\nCheck out the our free and community driven API at ${repository.url.replace(".git", "")}`;
+const helpText = `\nCheck out the our free and community driven API at ${repository.url.replace("/cli.git", "/api")}`;
 
 program
   .name(programName)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "private": false,
   "description": "A CLI for Helldivers 2: View the war progress without leaving your terminal! Powered by the HellHub API.",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "main": "build/index.mjs",
   "types": "build/index.d.ts",
   "keywords": [


### PR DESCRIPTION
## Description

This PR corrects the replacement of the package url to display the custom help text for the `help` command or the `--help` flag.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
