### PR TITLE
refractor: replace bundlephobia badge with bundlejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,8 @@
   <a href="https://github.com/hellhub-collective/cli/actions/workflows/test.yml">
     <img src="https://github.com/hellhub-collective/cli/actions/workflows/test.yml/badge.svg" alt="Tests" />
   </a>
-  <a href="https://bundlephobia.com/package/@hellhub-collective/cli">
-    <img src="https://img.shields.io/bundlephobia/min/@hellhub-collective/cli" alt="Bundle Size (Minified)" />
-  </a>
-  <a href="https://bundlephobia.com/package/@hellhub-collective/cli">
-    <img src="https://img.shields.io/bundlephobia/minzip/@hellhub-collective/cli" alt="Bundle Size (Minified & Zipped)" />
+  <a href="https://bundlejs.com/?q=%40hellhub-collective%2Fcli%40latest&treeshake=%5B*%5D">
+    <img src="https://deno.bundlejs.com/badge?q=@hellhub-collective/cli@latest&treeshake=[*]&config={%2Acompression%2A:%2Agzip%2A,%2Aesbuild%2A:{%2Aplatform%2A:%2Anode%2A}}" alt="Bundle Size (Minified & Zipped)" />
   </a>
 </p>
 


### PR DESCRIPTION
## Description

Replaces the bundlephobia badges showing the package size since they do not work correctly.

Fixes #4 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
